### PR TITLE
ENH: build/push also on pushes to master

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -4,6 +4,11 @@ on:
   pull_request:
   schedule:
     - cron: '0 */6 * * *'
+  push:
+    branches:
+      - master
+    paths:
+      - 'tools/make_webshots.py'
 
 jobs:
   update:
@@ -31,7 +36,7 @@ jobs:
         run: xvfb-run python tools/make_webshots.py
 
       - name: Commit changes
-        if: github.event_name == 'schedule'
+        if: github.event_name != 'pull_request'
         run: |
           git config --global user.email "team@dandiarchive.org"
           git config --global user.name "DANDI Bot"

--- a/tools/make_webshots.py
+++ b/tools/make_webshots.py
@@ -65,6 +65,7 @@ def process_dandiset(driver, ds):
         page_name.with_suffix('.html').write_text(driver.page_source)
         driver.save_screenshot(str(page_name.with_suffix('.png')))
 
+
     with (dspath / 'info.yaml').open('w') as f:
         yaml.safe_dump(info, f)
 


### PR DESCRIPTION
    To avoid infinite loop of pushes/action, should trigger only if there were
    changes to the script.  So we modify the script (will add some dummy changes in
    the next commit), and merge of that change should immediately trigger the
    action instead of waiting for cron.
