### PR TITLE
Set poll_frequency for wait_no_progressbar() to 0.1 seconds

### DIFF
--- a/tools/make_webshots.py
+++ b/tools/make_webshots.py
@@ -95,7 +95,7 @@ def login(driver, username, password):
 
 
 def wait_no_progressbar(driver, cls):
-    WebDriverWait(driver, 300).until(
+    WebDriverWait(driver, 300, poll_frequency=0.1).until(
         EC.invisibility_of_element_located((By.CLASS_NAME, cls)))
 
 


### PR DESCRIPTION
With this change, the landing times are much more evenly distributed.

Closes #8.